### PR TITLE
add --version to sherlodoc (0.2)

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -76,7 +76,8 @@ let cmd_jsoo =
 
 let cmd =
   let doc = "Sherlodoc" in
-  let info = Cmd.info "sherlodoc" ~doc in
+  let version = "0.2" in
+  let info = Cmd.info "sherlodoc" ~version ~doc in
   Cmd.group info [ cmd_search; cmd_index; cmd_serve; cmd_jsoo ]
 
 let () = exit (Cmd.eval cmd)

--- a/test/cram/version.t
+++ b/test/cram/version.t
@@ -1,0 +1,2 @@
+  $ sherlodoc --version
+  0.2


### PR DESCRIPTION
This makes cmdliner aware of the sherlodoc version, so that dune can know the installed version.