### PR TITLE
Enable sherlodoc on .odoc-index file for odoc 3 compat

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@
  (synopsis "Search engine for OCaml documentation")
  (depends
   (ocaml (>= 4.0.8))
-  (odoc (>= 2.4.0))
+  odoc
   (base64 (>= 3.5.1))
   (bigstringaf (>= 0.9.1))
   (js_of_ocaml (>= 5.6.0))

--- a/index/index.ml
+++ b/index/index.ml
@@ -80,7 +80,7 @@ let main
     let file = Fpath.v odoc in
     (match Fpath.(get_ext file) with
      | ".odocl" -> index_odocl_file (register ~pkg ~favourite) odoc
-     | ".odoc_index" ->
+     | ".odoc-index" ->
        index_odoc_index_file
          (fun _id entry ->
            Load_doc.register_entry

--- a/index/index.ml
+++ b/index/index.ml
@@ -21,7 +21,7 @@ let index_odoc_index_file register filename =
   | Error (`Msg msg) -> Format.printf "FILE ERROR %s: %s@." filename msg
   | Ok file ->
     (match Odoc_odoc.Odoc_file.load_index file with
-     | Ok entries -> Odoc_model.Paths.Identifier.Hashtbl.Any.iter register entries
+     | Ok entries -> Odoc_model.Paths.Identifier.Hashtbl.Any.iter register (snd entries)
      | Error (`Msg msg) -> Format.printf "Odoc warning or error %s: %s@." filename msg)
 
 let main

--- a/index/load_doc.ml
+++ b/index/load_doc.ml
@@ -150,7 +150,7 @@ let rec categorize id =
     | `ExtensionDecl _ | `Module _ ) as x ->
     let parent = Identifier.label_parent { id with iv = x } in
     categorize (parent :> Identifier.Any.t)
-  | `AssetFile _ | `SourceDir _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _
+  | `AssetFile _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _
   | `SourceLocationInternal _ ->
     `ignore (* unclear what to do with those *)
 

--- a/index/load_doc.ml
+++ b/index/load_doc.ml
@@ -185,7 +185,7 @@ let register_entry
   let rhs = Html.rhs_of_kind kind in
   let kind = convert_kind ~db entry in
   let cost = cost ~name ~kind ~doc_html ~rhs ~cat ~favourite ~favoured_prefixes in
-  let url = Result.get_ok (Html.url id) in
+  let url = Result.get_ok (Html.url entry) in
   let elt = Sherlodoc_entry.v ~name ~kind ~rhs ~doc_html ~cost ~url ~pkg () in
   if index_docstring then register_doc ~db elt doc_txt ;
   if index_name && kind <> Doc then register_full_name ~db elt ;
@@ -207,7 +207,7 @@ let register_entry
     | Doc _ -> true
     | _ -> false
   in
-  if is_pure_documentation || cat = `ignore || Odoc_model.Paths.Identifier.is_internal id
+  if is_pure_documentation || cat = `ignore || Odoc_model.Paths.Identifier.is_hidden id
   then ()
   else
     register_entry

--- a/index/typename.ml
+++ b/index/typename.ml
@@ -19,13 +19,23 @@ and show_signature h sig_ =
   | `ModuleType (_, p) ->
     Format.fprintf h "%s" (Odoc_model.Names.ModuleTypeName.to_string p)
 
-let show_type_name_verbose h : Path.Type.t -> _ = function
+let rec show_type_name_verbose h : Path.Type.t -> _ = function
   | `Resolved t ->
     Format.fprintf h "%a" show_ident_long Path.Resolved.(identifier (t :> t))
   | `Identifier (path, _hidden) ->
     let name = String.concat "." @@ Identifier.fullname path in
     Format.fprintf h "%s" name
-  | `Dot (mdl, x) ->
-    Format.fprintf h "%s.%s" (Odoc_document.Url.render_path (mdl :> Path.t)) x
+  | `SubstitutedT t -> show_type_name_verbose h t
+  | `DotT (mdl, x) ->
+    Format.fprintf
+      h
+      "%s.%s"
+      (Odoc_document.Url.render_path (mdl :> Path.t))
+      (Odoc_model.Names.TypeName.to_string_unsafe x)
 
 let to_string t = Format.asprintf "%a" show_type_name_verbose t
+
+type t =
+  | Hidden of string
+  | Shadowed of string * int * string
+  | Std of string

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -47,6 +47,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/art-w/sherlodoc.git"
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#master"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#master"]
 ]

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -47,6 +47,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/art-w/sherlodoc.git"
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#master"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#master"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc"]
 ]

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -47,6 +47,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/art-w/sherlodoc.git"
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#f3b0823d90cfeb6583925a1cf90c82e3e52da268"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#f3b0823d90cfeb6583925a1cf90c82e3e52da268"]
 ]

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -47,5 +47,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/art-w/sherlodoc.git"
 pin-depends: [
-  [ "odoc.dev" "git+https://github.com/ocaml/odoc#934fe014289074bd1690e3336e08d66a069b5991"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
 ]

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/art-w/sherlodoc/issues"
 depends: [
   "dune" {>= "3.5"}
   "ocaml" {>= "4.0.8"}
-  "odoc" {>= "2.4.0"}
+  "odoc"
   "base64" {>= "3.5.1"}
   "bigstringaf" {>= "0.9.1"}
   "js_of_ocaml" {>= "5.6.0"}

--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -46,3 +46,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/art-w/sherlodoc.git"
+pin-depends: [
+  [ "odoc.dev" "git+https://github.com/ocaml/odoc#934fe014289074bd1690e3336e08d66a069b5991"]
+]

--- a/sherlodoc.opam.template
+++ b/sherlodoc.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#master"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#master"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc"]
 ]

--- a/sherlodoc.opam.template
+++ b/sherlodoc.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#master"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#master"]
 ]

--- a/sherlodoc.opam.template
+++ b/sherlodoc.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
-  [ "odoc.dev"        "git+https://github.com/ocaml/odoc"]
-  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#f3b0823d90cfeb6583925a1cf90c82e3e52da268"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#f3b0823d90cfeb6583925a1cf90c82e3e52da268"]
 ]

--- a/sherlodoc.opam.template
+++ b/sherlodoc.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  [ "odoc.dev" "git+https://github.com/ocaml/odoc#934fe014289074bd1690e3336e08d66a069b5991"]
+]

--- a/sherlodoc.opam.template
+++ b/sherlodoc.opam.template
@@ -1,3 +1,4 @@
 pin-depends: [
-  [ "odoc.dev" "git+https://github.com/ocaml/odoc#934fe014289074bd1690e3336e08d66a069b5991"]
+  [ "odoc.dev"        "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
+  [ "odoc-parser.dev" "git+https://github.com/ocaml/odoc#442c7dd2e7870d920968710dd8cfd1d28016b9cc"]
 ]

--- a/test/cram/cli.t/run.t
+++ b/test/cram/cli.t/run.t
@@ -3,7 +3,7 @@
   $ odoc compile -I . page.mld
   $ odoc link -I . main.odoc
   $ odoc link -I . page-page.odoc
-  $ odoc compile-index -o index.odoc-index --include-rec .
+  $ odoc compile-index -o index.odoc-index -L '':.
   $ export SHERLODOC_DB=db.bin
   $ export SHERLODOC_FORMAT=marshal
   $ sherlodoc index  index.odoc-index

--- a/test/cram/cli.t/run.t
+++ b/test/cram/cli.t/run.t
@@ -3,9 +3,10 @@
   $ odoc compile -I . page.mld
   $ odoc link -I . main.odoc
   $ odoc link -I . page-page.odoc
+  $ odoc compile-index -o index.odoc-index --include-rec .
   $ export SHERLODOC_DB=db.bin
   $ export SHERLODOC_FORMAT=marshal
-  $ sherlodoc index $(find . -name '*.odocl')
+  $ sherlodoc index  index.odoc-index
   $ sherlodoc search "unique_name"
   val Main.unique_name : foo
   $ sherlodoc search "multiple_hit"


### PR DESCRIPTION
This adds support for the future odoc 3, which include generating .odoc-index files for sherlodoc to consume instead of consuming .odocl files directly. 

It works with the following odoc PR : https://github.com/ocaml/odoc/pull/1084 